### PR TITLE
Disable annoying attributes on input field

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
       <div id="typing-area">
         <div id="text-display"></div>
         <div class="bar">
-          <input id="input-field" type="text" />
+          <input id="input-field" type="text" spellcheck="false" autocomplete="off" autocorrect="off" autocapitalize="off" />
           <button id="redo-button" onclick="setText()">redo</button>
         </div>
       </div>


### PR DESCRIPTION
This pull request disables some—in this context—annoying attributes on the text input field:
* [`spellcheck="false"`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/spellcheck), disables spellchecking of input
* [`autocomplete="off"`](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete), disables autocompletion of values
* [`autocorrect="off"`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/text#autocorrect), disables autocorrection for Safari users
* [`autocapitalize="off"`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autocapitalize), disables automatic capitalization of first word for mobile users

Feel free to discuss below!