### PR TITLE
Hide theme center when clicking outside the panel

### DIFF
--- a/main.js
+++ b/main.js
@@ -258,6 +258,14 @@ document.addEventListener('keydown', e => {
   }
 });
 
+// mouse actions
+document.addEventListener('mouseup', e => {
+  if (e.target.nodeName === 'BODY' && !document.querySelector('#theme-center').classList.contains('hidden')) {
+    hideThemeCenter();
+    inputField.focus();
+  }
+});
+
 function setTheme(_theme) {
   const theme = _theme.toLowerCase();
   fetch(`themes/${theme}.css`)


### PR DESCRIPTION
As the title says. Hide the theme center when clicking on the body of the page, outside the panel.

![screencast](https://i.imgur.com/8aP0oeP.gif)