### PR TITLE
Restart typing test when pressing ESC

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ available themes:
 - `vilebloom` inspired by SA Vilebloom by u/UKKeycaps
 - `yuri` inspired by GMK Yuri by T0mb3ry
 
+## Redo
+
+ - Press `esc` to restart a typing test
+
 ## language
 
 type the language code for example `german` in the text box then hit [ windows: <kbd>alt</kbd> + <kbd>l</kbd> ], [ mac: <kbd>cmd</kbd> + <kbd>ctrl</kbd> + <kbd>l</kbd> ], [ linux: <kbd>super</kbd> + <kbd>ctrl</kbd> + <kbd>l</kbd> or <kbd>alt</kbd> + <kbd>l</kbd> ]

--- a/main.js
+++ b/main.js
@@ -255,6 +255,8 @@ document.addEventListener('keydown', e => {
       hideThemeCenter();
       inputField.focus();
     }
+  } else if (e.key === 'Escape') {
+    setText(e);
   }
 });
 


### PR DESCRIPTION
Instead of typing `tab`+`enter` to restart a typing test I added the option to press `ESC` to restart the test.