### PR TITLE
Hold shift while pressing Redo to keep the current word list

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ available themes:
 - `vilebloom` inspired by SA Vilebloom by u/UKKeycaps
 - `yuri` inspired by GMK Yuri by T0mb3ry
 
+## Redo
+
+- Hold `shift` while pressing Redo to Restart the typing test using the same word list.
+
 ## language
 
 type the language code for example `german` in the text box then hit [ windows: <kbd>alt</kbd> + <kbd>l</kbd> ], [ mac: <kbd>cmd</kbd> + <kbd>ctrl</kbd> + <kbd>l</kbd> ], [ linux: <kbd>super</kbd> + <kbd>ctrl</kbd> + <kbd>l</kbd> or <kbd>alt</kbd> + <kbd>l</kbd> ]

--- a/index.html
+++ b/index.html
@@ -54,7 +54,7 @@
         <div id="text-display"></div>
         <div class="bar">
           <input id="input-field" type="text" spellcheck="false" autocomplete="off" autocorrect="off" autocapitalize="off" tabindex="1"/>
-          <button id="redo-button" onclick="setText()" tabindex="2">redo</button>
+          <button id="redo-button" onclick="setText(event)" tabindex="2">redo</button>
         </div>
       </div>
     </div>

--- a/main.js
+++ b/main.js
@@ -26,9 +26,14 @@ getCookie('typingMode') === '' ? setTypingMode('wordcount') : setTypingMode(getC
 getCookie('punctuation') === '' ? setPunctuation('false') : setPunctuation(getCookie('punctuation'));
 
 // Find a list of words and display it to textDisplay
-function setText() {
+function setText(e) {
+  e = e || window.event;
+  var keepWordList = e && e.shiftKey;
+
   // Reset
-  wordList = [];
+  if (!keepWordList) {
+    wordList = [];
+  }
   currentWord = 0;
   correctKeys = 0;
   inputField.value = '';
@@ -41,11 +46,13 @@ function setText() {
     case 'wordcount':
       textDisplay.style.height = 'auto';
       textDisplay.innerHTML = '';
-      wordList = [];
-      while (wordList.length < wordCount) {
-        const randomWord = randomWords[Math.floor(Math.random() * randomWords.length)];
-        if (wordList[wordList.length - 1] !== randomWord || wordList[wordList.length - 1] === undefined || getCookie('language') === 'dots') {
-          wordList.push(randomWord);
+      if (!keepWordList) {
+        wordList = [];
+        while (wordList.length < wordCount) {
+          const randomWord = randomWords[Math.floor(Math.random() * randomWords.length)];
+          if (wordList[wordList.length - 1] !== randomWord || wordList[wordList.length - 1] === undefined || getCookie('language') === 'dots') {
+            wordList.push(randomWord);
+          }
         }
       }
       break;
@@ -54,10 +61,12 @@ function setText() {
       textDisplay.style.height = '3.2rem';
       document.querySelector(`#tc-${timeCount}`).innerHTML = timeCount;
       textDisplay.innerHTML = '';
-      wordList = [];
-      for (i = 0; i < 500; i++) {
-        let n = Math.floor(Math.random() * randomWords.length);
-        wordList.push(randomWords[n]);
+      if (!keepWordList) {
+        wordList = [];
+        for (i = 0; i < 500; i++) {
+          let n = Math.floor(Math.random() * randomWords.length);
+          wordList.push(randomWords[n]);
+        }
       }
   }
 


### PR DESCRIPTION
Based on user request #26 I implemented an easy way to restart a typing test using the same word list by holding `shift` while pressing redo. (Also works when you focus on redo and press `shift`+`enter`)