### PR TITLE
Fixes #95

### DIFF
--- a/main.js
+++ b/main.js
@@ -118,27 +118,6 @@ function showText() {
 
 // Key is pressed in input field
 inputField.addEventListener('keydown', e => {
-  // Add wrong class to input field
-  switch (typingMode) {
-    case 'wordcount':
-      if (currentWord < wordList.length) inputFieldClass();
-    case 'time':
-      if (timerActive) inputFieldClass();
-  }
-  function inputFieldClass() {
-    if (e.key >= 'a' && e.key <= 'z' || (e.key === `'` || e.key === ',' || e.key === '.' || e.key === ';')) {
-      let inputWordSlice = inputField.value + e.key;
-      let currentWordSlice = wordList[currentWord].slice(0, inputWordSlice.length);
-      inputField.className = inputWordSlice === currentWordSlice ? '' : 'wrong';
-    } else if (e.key === 'Backspace') {
-      let inputWordSlice = e.ctrlKey ? '' : inputField.value.slice(0, inputField.value.length - 1);
-      let currentWordSlice = wordList[currentWord].slice(0, inputWordSlice.length);
-      inputField.className = inputWordSlice === currentWordSlice ? '' : 'wrong';
-    } else if (e.key === ' ') {
-      inputField.className = '';
-    }
-  }
-
   // If it is the first character entered
   if (currentWord === 0 && inputField.value === '') {
     switch (typingMode) {
@@ -208,6 +187,26 @@ inputField.addEventListener('keydown', e => {
       correctKeys += wordList[currentWord].length;
       currentWord++;
       showResult();
+    }
+  }
+});
+
+// Key is lifted up in input field
+inputField.addEventListener('keyup', e => {
+  // Add wrong class to input field
+  switch (typingMode) {
+    case 'wordcount':
+      if (currentWord < wordList.length) inputFieldClass();
+    case 'time':
+      if (timerActive) inputFieldClass();
+  }
+  function inputFieldClass() {
+    if (e.key === ' ') {
+      inputField.className = '';
+    } else {
+      let inputWordSlice = inputField.value;
+      let currentWordSlice = wordList[currentWord].slice(0, inputWordSlice.length);
+      inputField.className = inputWordSlice.length === 0 || inputWordSlice === currentWordSlice ? '' : 'wrong';
     }
   }
 });


### PR DESCRIPTION
Fixes #95 

*I'd like to apologize ahead of time for making a lot of assumptions and not having a lot of answers in this PR. I wouldn't be offended if you choose to close it. I saw this issue firsthand and wanted to solve it, but my expertise is in Swift, so I'm not well-equipped to handle the fix.*

> When we type wrong letters, typings.gg is making the text box red in color. This means that typings.gg is highlighting the text box when there is an error in our word. But when we type something in wrong case, like "Long" instead of "long", we are not getting the text box highlighting. But when we type "Long" and hit space, the word is marked as error in the paragraph, like we can see in another image.

Simply adding

```js
e.key >= 'A' && e.key <= 'Z'
```

to the `if` statement does not solve the problem. Not only would this capture keys like `CapsLock` and `Shift`, but it also potentially ignores non-Latin characters (not 100% sure if this is true - can someone verify?).

Theoretically, you could have a set of all valid characters and construct `inputWordSlice` only if a valid character has been typed. This would unfortunately require inputting *every single supported character into a set*. I don't think that's maintainable.

Alternatively, instead of checking if `e.key` belongs to some range, you could check if `e.key.length === 1`. If it's `>1`, it's probably a key like `Control`, and shouldn't be appended to the input. Of course, you'd still need to check for `Backspace` ahead of time, since that's actually *removing* a character (and shouldn't you check for `Delete`?). I decided against this because I don't trust this approach. I code professionally in Swift where single characters do not necessarily have `length == 1`, e.g. emojis, and `String`s have indexing rules that don't have a one-to-one mapping with `Array`s! Is it guaranteed that every alphanumeric character in JavaScript is `length == 1`? If so, maybe I could use that change instead, but I'd still be worried about the `Delete` question I posed.

If we instead determine whether or not a word is right or wrong on keyup rather than keydown, the input has already been changed. We don't need to construct it, check if the key would actually add to the string, etc. The string has already mutated and its updated value can be accessed with `inputField.value`. The consequence is that this operation happens *after* keydown, and it still breaks if you hold down a key, but I think it's more likely that you accidentally hit Caps Lock and are (mis)led to believe that your input is right than you hold down a key and *immediately* hit space before you realize your mistake.